### PR TITLE
Output test results after call to ecc provision

### DIFF
--- a/src/cli/gateway_mfr_cli_ecc.erl
+++ b/src/cli/gateway_mfr_cli_ecc.erl
@@ -70,7 +70,7 @@ ecc_test_usage() ->
      ]
     ].
 
-ecc_test(["ecc", "test"], [], []) ->
+ecc_test_results() ->
     TestResults = gateway_mfr_worker:ecc_test(),
     FormatResult = fun({Name, Result}) ->
                            [{name, Name}, {result, Result}]
@@ -79,6 +79,10 @@ ecc_test(["ecc", "test"], [], []) ->
                  true -> 0;
                  _ -> 1
              end,
+    {Status, FormatResult, TestResults}.
+
+ecc_test(["ecc", "test"], [], []) ->
+    {Status, FormatResult, TestResults} = ecc_test_results(),
     {exit_status, Status, [clique_status:table(lists:map(FormatResult, TestResults))]};
 ecc_test([_, _, _], [], []) ->
     usage.
@@ -108,18 +112,12 @@ ecc_provision_usage() ->
 ecc_provision(["ecc", "provision"], [], []) ->
     case gateway_mfr_worker:ecc_provision() of
         {ok, B58Key} ->
-            TestResults = gateway_mfr_worker:ecc_test(),
-            FormatResult = fun({Name, Result}) ->
-                                   [{name, Name}, {result, Result}]
-                           end,
-            Status = case lists:all(fun({_, S}) -> S == ok end, TestResults) of
-                         true -> 0;
-                         _ -> 1
-                     end,
+            {Status, FormatResult, TestResults} = ecc_test_results(),
             {exit_status, Status, [clique_status:text(B58Key), clique_status:table(lists:map(FormatResult, TestResults))]};
         {error, Error} ->
             Msg = io_lib:format("~p", [Error]),
-            {exit_status, 1, [clique_status:alert([clique_status:text(Msg)])]}
+            {_Status, FormatResult, TestResults} = ecc_test_results(),
+            {exit_status, 1, [clique_status:alert([clique_status:text(Msg), clique_status:table(lists:map(FormatResult, TestResults))])]}
     end;
 ecc_provision([_, _], [], []) ->
     usage.


### PR DESCRIPTION
This pull requests eliminates the need to call `gateway_mfr ecc test` seconds after calling `gateway_mfr ecc provision`.

```
$ sudo /opt/gateway_mfr/bin/gateway_mfr ecc provision
stty: standard input
{zone_locked,[{config,true},{data,true}]}
+--------------------+------+
|        name        |result|
+--------------------+------+
|     serial_num     |  ok  |
|{zone_locked,config}|  ok  |
| {zone_locked,data} |  ok  |
|    slot_config     |  ok  |
|     key_config     |  ok  |
|   onboarding_key   |  ok  |
|  {slot_locked,15}  |  ok  |
+--------------------+------+

$ echo $?
1
```